### PR TITLE
fix(Travis Build): Travis build was failing due to node-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "lodash.kebabcase": "^4.1.1",
     "lodash.set": "^4.3.2",
     "node-notifier": "^5.1.2",
-    "node-typescript": "^0.1.3",
     "npm-run-all": "^4.1.2",
     "offline-plugin": "^4.8.3",
     "path": "^0.12.7",


### PR DESCRIPTION
Removed node-typescript dependency because Travis build was failing.